### PR TITLE
Add Next.js configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+require('dotenv').config({ path: '.env.local' });
+
+const nextConfig = {
+  reactStrictMode: true,
+  // Static files are served from the `public` directory by default
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js with React strict mode
- load env vars from `.env.local`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467832d2188328977b056cadc6c0ff