### PR TITLE
Add Jest config and placeholder test

### DIFF
--- a/__tests__/placeholder.test.ts
+++ b/__tests__/placeholder.test.ts
@@ -1,0 +1,3 @@
+test('placeholder', () => {
+  expect(true).toBe(true);
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/__tests__/**/*.(spec|test).(ts|js)'],
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "next": "13.x",
@@ -15,6 +16,9 @@
   "devDependencies": {
     "tailwindcss": "^3.0.0",
     "postcss": "^8.0.0",
-    "autoprefixer": "^10.0.0"
+    "autoprefixer": "^10.0.0",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^29.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- set up Jest and TypeScript support
- add placeholder test

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467a1663208328acc1759719abd99d