### PR TITLE
Add landing page linking to hub

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-900">
+      <Link
+        href="/rooms/hub"
+        className="px-8 py-4 text-2xl font-bold text-white bg-blue-600 rounded hover:bg-blue-700"
+      >
+        Enter H4LO 3D Store
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/pages/index.tsx` with a button linking to `/rooms/hub`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467afa4ab483289b4d126f828f18e0