### PR TITLE
feat: explore view toggle

### DIFF
--- a/src/app/components/DiscoveryGrid.tsx
+++ b/src/app/components/DiscoveryGrid.tsx
@@ -1,0 +1,10 @@
+'use client';
+import React from 'react';
+import { ProductGrid } from './ProductGrid';
+import { products } from '../../data/products';
+
+export default function DiscoveryGrid() {
+  return (
+    <ProductGrid products={products} onSelectProduct={() => {}} />
+  );
+}

--- a/src/app/components/DiscoveryMap.tsx
+++ b/src/app/components/DiscoveryMap.tsx
@@ -1,0 +1,10 @@
+'use client';
+import React from 'react';
+
+export default function DiscoveryMap() {
+  return (
+    <div className="w-full h-96 flex items-center justify-center border rounded-lg">
+      <p className="text-gray-500">World map placeholder</p>
+    </div>
+  );
+}

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,33 +1,52 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import DiscoveryGrid from '../components/DiscoveryGrid';
 import DiscoveryMap from '../components/DiscoveryMap';
 
 export default function ExplorePage() {
   const [viewMode, setViewMode] = useState<'grid' | 'map'>('grid');
+  const [scrollY, setScrollY] = useState(0);
 
   const buttonClass = (mode: 'grid' | 'map') =>
     `px-4 py-2 border border-black text-sm ${viewMode === mode ? 'bg-black text-white' : 'bg-white'}`;
+
+  const switchMode = (mode: 'grid' | 'map') => {
+    if (mode === viewMode) return;
+    if (viewMode === 'grid') {
+      setScrollY(window.scrollY);
+    }
+    setViewMode(mode);
+  };
+
+  useEffect(() => {
+    if (viewMode === 'grid') {
+      window.scrollTo(0, scrollY);
+    }
+  }, [viewMode, scrollY]);
 
   return (
     <div className="p-6">
       <div className="flex justify-end gap-2 mb-4">
         <button
+          aria-label="Toggle view"
           className={`${buttonClass('grid')} rounded-l`}
-          onClick={() => setViewMode('grid')}
+          onClick={() => switchMode('grid')}
         >
           <span className="hidden md:inline">View as Grid</span>
           <span className="md:hidden">🔳</span>
         </button>
         <button
+          aria-label="Toggle view"
           className={`${buttonClass('map')} rounded-r`}
-          onClick={() => setViewMode('map')}
+          onClick={() => switchMode('map')}
         >
           <span className="hidden md:inline">View on Map</span>
           <span className="md:hidden">🗺️</span>
         </button>
       </div>
-      {viewMode === 'grid' ? <DiscoveryGrid /> : <DiscoveryMap />}
+      <div key={viewMode} className="transition-opacity duration-300">
+        {viewMode === 'grid' ? <DiscoveryGrid /> : <DiscoveryMap />}
+      </div>
     </div>
   );
 }

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+import React, { useState } from 'react';
+import DiscoveryGrid from '../components/DiscoveryGrid';
+import DiscoveryMap from '../components/DiscoveryMap';
+
+export default function ExplorePage() {
+  const [viewMode, setViewMode] = useState<'grid' | 'map'>('grid');
+
+  const buttonClass = (mode: 'grid' | 'map') =>
+    `px-4 py-2 border border-black text-sm ${viewMode === mode ? 'bg-black text-white' : 'bg-white'}`;
+
+  return (
+    <div className="p-6">
+      <div className="flex justify-end gap-2 mb-4">
+        <button
+          className={`${buttonClass('grid')} rounded-l`}
+          onClick={() => setViewMode('grid')}
+        >
+          <span className="hidden md:inline">View as Grid</span>
+          <span className="md:hidden">🔳</span>
+        </button>
+        <button
+          className={`${buttonClass('map')} rounded-r`}
+          onClick={() => setViewMode('map')}
+        >
+          <span className="hidden md:inline">View on Map</span>
+          <span className="md:hidden">🗺️</span>
+        </button>
+      </div>
+      {viewMode === 'grid' ? <DiscoveryGrid /> : <DiscoveryMap />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add DiscoveryGrid/DiscoveryMap components as placeholders
- implement toggle buttons on `/explore` to swap between grid and map views

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd51ca72483288ed86b6f6b1d4bd9